### PR TITLE
Update print.php

### DIFF
--- a/print/print.php
+++ b/print/print.php
@@ -35,9 +35,14 @@ global $withcomments;
 $withcomments = true;
 
 ### Load Print Post/Page Template
+/*
 if(file_exists(TEMPLATEPATH.'/print-posts.php')) {
 	include(TEMPLATEPATH.'/print-posts.php');
 } else {
 	include(WP_PLUGIN_DIR.'/delibera/print/print-posts.php');
 }
+*/
+
+get_template_part( 'print', 'posts' );
+
 ?>


### PR DESCRIPTION
É desnecessário esse IF.
Essa verificação sempre retorna true, pois o arquivo existe no diretório.
Deveria ser removido, para economizar recursos do servidor.

Trocar esses includes pela função nativa do WordPress "get_template_part", descrita em:
https://codex.wordpress.org/Include_Tags
https://codex.wordpress.org/Function_Reference/get_template_part